### PR TITLE
docs: fix typo in components doc

### DIFF
--- a/packages/docs/open-source/internals/components.md
+++ b/packages/docs/open-source/internals/components.md
@@ -364,7 +364,7 @@ const movieDB = await create({
   },
   components: {
     validateSchema(doc) {
-      return typeof doc.name === 'string && typeof doc.director === 'string'
+      return typeof doc.name === 'string' && typeof doc.director === 'string'
     }
   }
 })


### PR DESCRIPTION
Fixed a typo in the example snippet for the `validateSchema` component