### PR TITLE
Fix getNanosecondsTime when process is not defined

### DIFF
--- a/packages/orama/src/utils.ts
+++ b/packages/orama/src/utils.ts
@@ -122,7 +122,7 @@ export async function getNanosecondsTime(): Promise<bigint> {
     return process.hrtime.bigint()
   }
 
-  if (process?.hrtime) {
+  if (typeof process !== 'undefined' && typeof process?.hrtime?.bigint === 'function') {
     return process.hrtime.bigint()
   }
 


### PR DESCRIPTION
In the browser there's no "process", and this throws an error in strict mode.