### PR TITLE
docs: updated docs to correctly show what section in wip

### DIFF
--- a/packages/docs/cloud/data-sources/custom-integrations/introduction.md
+++ b/packages/docs/cloud/data-sources/custom-integrations/introduction.md
@@ -14,8 +14,8 @@ As for today, we support 4 different ways to feed Orama with your data:
 
 - [JSON File Upload](./json-file)
 - [CSV FIle Upload](./csv-file)
-- [REST API](./rest-api)
-- [WebHooks](./webhooks) (work in progress)
+- [REST API](./rest-api) (work in progress)
+- [WebHooks](./webhooks)
 
 You can use any of the above methods to feed Orama with your data. You can even use all of them at the same time on different indexes.
 


### PR DESCRIPTION
In the Orama Cloud docs Custom Integrations Webhook doc is marked as WIP https://docs.askorama.ai/cloud/data-sources/custom-integrations/introduction.html but in reality REST API are WIP, while Webhook section seems to be ready.

P.S.: there's nothing in contribution guidelines about directly editing page from GH, so no template for this PR :D 