### PR TITLE
perf(orama): prefer flatMap

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -631,9 +631,7 @@ export async function searchByWhereClause<T extends AnyOrama, ResultDocument = T
   }
 
   // AND operation: calculate the intersection between all the IDs in filterMap
-  const result = intersect(Object.values(filtersMap))
-
-  return result
+  return intersect(Object.values(filtersMap))
 }
 
 export async function getSearchableProperties(index: Index): Promise<string[]> {

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -553,7 +553,7 @@ export async function searchByWhereClause<T extends AnyOrama, ResultDocument = T
           highPrecision
         )
         // @todo: convert this into a for loop
-        safeArrayPush(filtersMap[param], ids.map(({ docIDs }) => docIDs).flat())
+        safeArrayPush(filtersMap[param], ids.flatMap(({ docIDs }) => docIDs))
       } else {
         const {
           coordinates,
@@ -562,7 +562,7 @@ export async function searchByWhereClause<T extends AnyOrama, ResultDocument = T
         } = operation[reqOperation] as GeosearchPolygonOperator['polygon']
         const ids = searchByPolygon(node.root, coordinates as BKDGeoPoint[], inside, undefined, highPrecision)
         // @todo: convert this into a for loop
-        safeArrayPush(filtersMap[param], ids.map(({ docIDs }) => docIDs).flat())
+        safeArrayPush(filtersMap[param], ids.flatMap(({ docIDs }) => docIDs))
       }
 
       continue

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -587,11 +587,9 @@ export async function searchByWhereClause<T extends AnyOrama, ResultDocument = T
     }
 
     if (type === 'Flat') {
-      if (isArray) {
-        safeArrayPush(filtersMap[param], flatFilterArr(node, operation as EnumArrComparisonOperator))
-      } else {
-        safeArrayPush(filtersMap[param], flatFilter(node, operation as EnumComparisonOperator))
-      }
+      const flatOperation = isArray ? flatFilterArr : flatFilter
+      safeArrayPush(filtersMap[param], flatOperation(node, operation as EnumComparisonOperator & EnumArrComparisonOperator))
+
       continue
     }
 

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -118,9 +118,7 @@ export default function OramaPluginDocusaurus(ctx: {
         }
       })
 
-      const oramaDocs = [
-        ...await Promise.all(allOramaDocsPromises)
-      ]
+      const oramaDocs = (await Promise.all(allOramaDocsPromises))
         .flat()
         .map((data) => ({
           title: data.title,

--- a/packages/plugin-vitepress/src/index.ts
+++ b/packages/plugin-vitepress/src/index.ts
@@ -42,8 +42,7 @@ async function createOramaContentLoader(paths: string[], root: string, base: str
       html: md.render(readFileSync(file, 'utf-8'), '')
     }))
     .map(parseHTMLContent)
-    .map((data) => formatForOrama(data, base))
-    .flat()
+    .flatMap((data) => formatForOrama(data, base))
 
   const db = await create({
     schema: presets.docs.schema


### PR DESCRIPTION
As a perf improvement, use `flatMap` instead of `.map(...).flat`