### PR TITLE
[Plugin Vitepress] fix case when item has no h1

### DIFF
--- a/packages/plugin-vitepress/src/index.ts
+++ b/packages/plugin-vitepress/src/index.ts
@@ -90,7 +90,7 @@ function formatForOrama(data: Array<ParserResult>, base: string): Array<OramaSch
     return data.map((res) => ({
       title: res.title,
       content: res.content,
-      section: firstH1Header!.title.replace(/\s$/, ''),
+      section: (firstH1Header?.title || "").replace(/\s$/, ""),
       path: base + res?.path + '#' + slugify.default(res.title, { lower: true }),
       category: ''
     }))


### PR DESCRIPTION
Prevents plugin from breaking when a page doesn't have an h1

closes https://github.com/askorama/orama/issues/701