### PR TITLE
fix(hybrid search results): fixed hybrid search by removing redundant…

### DIFF
--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -108,7 +108,7 @@ export async function hybridSearch<T extends AnyOrama, ResultDocument = TypedDoc
   const timeEnd = await getNanosecondsTime()
 
   const returningResults = {
-    count: uniqueTokenScores.length,
+    count: uniqueTokenScores.slice(offset, offset+limit).length,
     elapsed: {
       raw: Number(timeEnd - timeStart),
       formatted: await formatNanoseconds(timeEnd - timeStart)

--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -108,7 +108,7 @@ export async function hybridSearch<T extends AnyOrama, ResultDocument = TypedDoc
   const timeEnd = await getNanosecondsTime()
 
   const returningResults = {
-    count: uniqueTokenScores.slice(offset, offset+limit).length,
+    count: uniqueTokenScores.length,
     elapsed: {
       raw: Number(timeEnd - timeStart),
       formatted: await formatNanoseconds(timeEnd - timeStart)

--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -85,7 +85,7 @@ export async function hybridSearch<T extends AnyOrama, ResultDocument = TypedDoc
 
   if (hasFilters) {
     whereFiltersIDs = await orama.index.searchByWhereClause(context, index, params.where!)
-    uniqueTokenScores = intersectFilteredIDs(whereFiltersIDs, uniqueTokenScores).slice(offset, offset + limit)
+    uniqueTokenScores = intersectFilteredIDs(whereFiltersIDs, uniqueTokenScores)
   }
 
   let facetsResults: any
@@ -155,7 +155,7 @@ async function getFullTextSearchIDs<T extends AnyOrama, ResultDocument = TypedDo
   if (properties && properties !== '*') {
     const propertiesToSearchSet = new Set(propertiesToSearch)
     const propertiesSet = new Set(properties as string[])
-    
+
     for (const prop of properties) {
       if (!propertiesToSearchSet.has(prop as string)) {
         throw createError('UNKNOWN_INDEX', prop as string, propertiesToSearch.join(', '))
@@ -285,7 +285,7 @@ function mergeAndRankResults(
   vectorResults: TokenScore[],
   query: string,
   hybridWeights: HybridWeights | undefined
-) { 
+) {
   // eslint-disable-next-line prefer-spread
   const maxTextScore = Math.max.apply(Math, textResults.map(extractScore))
   // eslint-disable-next-line prefer-spread

--- a/packages/orama/tests/search.hybrid.test.ts
+++ b/packages/orama/tests/search.hybrid.test.ts
@@ -146,10 +146,13 @@ t.test('hybrid search', async (t) => {
       offset: 2
     })
 
-    t.equal(page1.count, 20)
-    t.equal(page2.count, 20)
-    t.equal(page3.count, 20)
-
+    //ideally this has to show 2. not sure why it is like this
+    // t.equal(page1.count, 20)
+    // t.equal(page2.count, 20)
+    // t.equal(page3.count, 20)
+    t.equal(page1.count, 2)
+    t.equal(page2.count, 2)
+    t.equal(page3.count, 2)
     t.equal(page1.hits.length, 2)
     t.equal(page2.hits.length, 2)
     t.equal(page3.hits.length, 2)
@@ -295,6 +298,11 @@ t.test('should fix the issue realted #730', async (t) => {
   t.equal(page2.hits.length, 2)
   t.equal(page3.hits.length, 2)
   t.equal(page4.hits.length, 10)
+  t.equal(page4.hits.length, 10)
+  t.equal(page1.count, 2)
+  t.equal(page2.count, 2)
+  t.equal(page3.count, 2)
+  t.equal(page4.count, 10)
 })
 
 

--- a/packages/orama/tests/search.hybrid.test.ts
+++ b/packages/orama/tests/search.hybrid.test.ts
@@ -198,3 +198,103 @@ t.test('hybrid search', async (t) => {
     t.equal(results.hits[1].score, 0.5)
   })
 })
+
+t.test('should fix the issue realted #730', async (t) => {
+  const db = await create({
+    schema: {
+      text: "string",
+      embedding: "vector[5]",
+      number: "number",
+      itemId: "string",
+    } as const,
+  });
+
+  await insertMultiple(db, [
+    { "text": "hello world", "itemId": "1", "embedding": [1, 2, 3, 4, 5], "number": 1 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 2 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 3 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 4 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 5 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 6 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 7 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 8 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 9 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 10 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 11 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 12 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 13 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 14 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 15 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 16 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 17 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 18 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 19 },
+    { "text": "hello there", "itemId": "1", "embedding": [1, 2, 3, 4, 4], "number": 20 }
+  ]
+  );
+
+  const page1 = await search(db, {
+    term: "hello there",
+    mode: "hybrid",
+    where: {
+      itemId: "1",
+    },
+    vector: {
+      property: "embedding",
+      value: [1, 2, 3, 4, 4],
+    },
+    similarity: 0.5,
+    limit: 2,
+    offset: 0,
+  });
+
+  const page2 = await search(db, {
+    term: "hello there",
+    mode: "hybrid",
+    where: {
+      itemId: "1",
+    },
+    vector: {
+      property: "embedding",
+      value: [1, 2, 3, 4, 4],
+    },
+    similarity: 0.5,
+    limit: 2,
+    offset: 1,
+  });
+
+  const page3 = await search(db, {
+    term: "hello there",
+    mode: "hybrid",
+    where: {
+      itemId: "1",
+    },
+    vector: {
+      property: "embedding",
+      value: [1, 2, 3, 4, 4],
+    },
+    similarity: 0.5,
+    limit: 2,
+    offset: 2,  
+  });
+  const page4 = await search(db, {
+    term: "hello there",
+    mode: "hybrid",
+    where: {
+      itemId: "1",
+    },
+    vector: {
+      property: "embedding",
+      value: [1, 2, 3, 4, 4],
+    },
+    similarity: 0.5,
+    limit: 10,
+    offset: 5,  
+  })
+  t.equal(page1.hits.length, 2)
+  t.equal(page2.hits.length, 2)
+  t.equal(page3.hits.length, 2)
+  t.equal(page4.hits.length, 10)
+})
+
+

--- a/packages/orama/tests/search.hybrid.test.ts
+++ b/packages/orama/tests/search.hybrid.test.ts
@@ -198,7 +198,7 @@ t.test('hybrid search', async (t) => {
   })
 })
 
-t.test('should fix the issue realted #730', async (t) => {
+t.test('should correctly paginate the results with a where clause', async (t) => {
   const db = await create({
     schema: {
       text: "string",
@@ -294,6 +294,17 @@ t.test('should fix the issue realted #730', async (t) => {
   t.equal(page2.hits.length, 2)
   t.equal(page3.hits.length, 2)
   t.equal(page4.hits.length, 10)
+
+
+  t.equal(page1.hits[0].document.number, 2)
+  t.equal(page1.hits[1].document.number, 3)
+
+  t.equal(page2.hits[0].document.number, 3)
+  t.equal(page2.hits[1].document.number, 4)
+
+  t.equal(page3.hits[0].document.number, 4)
+  t.equal(page3.hits[1].document.number, 5)
+  
   t.equal(page1.count, 20)
   t.equal(page2.count, 20)
   t.equal(page3.count, 20)

--- a/packages/orama/tests/search.hybrid.test.ts
+++ b/packages/orama/tests/search.hybrid.test.ts
@@ -146,13 +146,9 @@ t.test('hybrid search', async (t) => {
       offset: 2
     })
 
-    //ideally this has to show 2. not sure why it is like this
-    // t.equal(page1.count, 20)
-    // t.equal(page2.count, 20)
-    // t.equal(page3.count, 20)
-    t.equal(page1.count, 2)
-    t.equal(page2.count, 2)
-    t.equal(page3.count, 2)
+    t.equal(page1.count, 20)
+    t.equal(page2.count, 20)
+    t.equal(page3.count, 20)
     t.equal(page1.hits.length, 2)
     t.equal(page2.hits.length, 2)
     t.equal(page3.hits.length, 2)
@@ -298,11 +294,10 @@ t.test('should fix the issue realted #730', async (t) => {
   t.equal(page2.hits.length, 2)
   t.equal(page3.hits.length, 2)
   t.equal(page4.hits.length, 10)
-  t.equal(page4.hits.length, 10)
-  t.equal(page1.count, 2)
-  t.equal(page2.count, 2)
-  t.equal(page3.count, 2)
-  t.equal(page4.count, 10)
+  t.equal(page1.count, 20)
+  t.equal(page2.count, 20)
+  t.equal(page3.count, 20)
+  t.equal(page4.count, 20)
 })
 
 


### PR DESCRIPTION
/claim #730 
/fixes #730 

… slicing before filtering

results were sliced and then filtered, causing incorrect document return and an upper-bounded count value. Now, filtering is done first to ensure accurate total count and correct document retrieval.

demo video:
https://www.loom.com/share/63cc6cfee37c434596d79750977d5dff