### PR TITLE
fix: prevent double pagination and bad count value

### DIFF
--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -85,7 +85,7 @@ export async function hybridSearch<T extends AnyOrama, ResultDocument = TypedDoc
 
   if (hasFilters) {
     whereFiltersIDs = await orama.index.searchByWhereClause(context, index, params.where!)
-    uniqueTokenScores = intersectFilteredIDs(whereFiltersIDs, uniqueTokenScores).slice(offset, offset + limit)
+    uniqueTokenScores = intersectFilteredIDs(whereFiltersIDs, uniqueTokenScores)
   }
 
   let facetsResults: any
@@ -155,7 +155,7 @@ async function getFullTextSearchIDs<T extends AnyOrama, ResultDocument = TypedDo
   if (properties && properties !== '*') {
     const propertiesToSearchSet = new Set(propertiesToSearch)
     const propertiesSet = new Set(properties as string[])
-    
+
     for (const prop of properties) {
       if (!propertiesToSearchSet.has(prop as string)) {
         throw createError('UNKNOWN_INDEX', prop as string, propertiesToSearch.join(', '))
@@ -285,7 +285,7 @@ function mergeAndRankResults(
   vectorResults: TokenScore[],
   query: string,
   hybridWeights: HybridWeights | undefined
-) { 
+) {
   // eslint-disable-next-line prefer-spread
   const maxTextScore = Math.max.apply(Math, textResults.map(extractScore))
   // eslint-disable-next-line prefer-spread

--- a/packages/orama/tests/search.hybrid.test.ts
+++ b/packages/orama/tests/search.hybrid.test.ts
@@ -165,6 +165,103 @@ t.test('hybrid search', async (t) => {
     t.equal(page3.hits[1].document.number, 5)
   })
 
+  t.test('should correctly paginate the results with a where clause', async (t) => {
+    const db = await create({
+      schema: {
+        text: 'string',
+        embedding: 'vector[5]',
+        number: 'number',
+        itemId: 'string'
+      } as const
+    })
+
+    await insertMultiple(db, [
+      { text: 'hello world', itemId: '1', embedding: [1, 2, 3, 4, 5], number: 1 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 2 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 3 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 4 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 5 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 6 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 7 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 8 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 9 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 10 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 11 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 12 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 13 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 14 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 15 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 16 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 17 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 18 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 19 },
+      { text: 'hello there', itemId: '1', embedding: [1, 2, 3, 4, 4], number: 20 }
+    ])
+
+    const page1 = await search(db, {
+      term: 'hello there',
+      mode: 'hybrid',
+      where: {
+        itemId: '1'
+      },
+      vector: {
+        property: 'embedding',
+        value: [1, 2, 3, 4, 4]
+      },
+      similarity: 0.5,
+      limit: 2,
+      offset: 0
+    })
+
+    const page2 = await search(db, {
+      term: 'hello there',
+      mode: 'hybrid',
+      where: {
+        itemId: '1'
+      },
+      vector: {
+        property: 'embedding',
+        value: [1, 2, 3, 4, 4]
+      },
+      similarity: 0.5,
+      limit: 2,
+      offset: 1
+    })
+
+    const page3 = await search(db, {
+      term: 'hello there',
+      mode: 'hybrid',
+      where: {
+        itemId: '1'
+      },
+      vector: {
+        property: 'embedding',
+        value: [1, 2, 3, 4, 4]
+      },
+      similarity: 0.5,
+      limit: 2,
+      offset: 2
+    })
+
+    t.equal(page1.count, 20)
+    t.equal(page2.count, 20)
+    t.equal(page3.count, 20)
+
+    t.equal(page1.hits.length, 2)
+    t.equal(page2.hits.length, 2)
+    t.equal(page3.hits.length, 2)
+
+    // Result with number 1 is skipped since it's not similar enough
+    t.equal(page1.hits[0].document.number, 2)
+    t.equal(page1.hits[1].document.number, 3)
+
+    t.equal(page2.hits[0].document.number, 3)
+    t.equal(page2.hits[1].document.number, 4)
+
+    t.equal(page3.hits[0].document.number, 4)
+    t.equal(page3.hits[1].document.number, 5)
+  })
+
   t.test('should use custom weights correctly', async (t) => {
     const db = await create({
       schema: {


### PR DESCRIPTION
Fixes https://github.com/askorama/orama/issues/730 by removing the double pagination which upperbounded the count value and caused some missed documents in the documents fetching later in the execution path.