### PR TITLE
Feat/docusaurus v3 fixes

### DIFF
--- a/packages/plugin-docusaurus-v3/package.json
+++ b/packages/plugin-docusaurus-v3/package.json
@@ -13,8 +13,8 @@
     "url": "git+https://github.com/orama/orama.git"
   },
   "sideEffects": false,
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "postbuild": "sh scripts/postbuild.sh",

--- a/packages/plugin-docusaurus-v3/scripts/postbuild.sh
+++ b/packages/plugin-docusaurus-v3/scripts/postbuild.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cp src/theme/SearchBar/*.css lib/theme/SearchBar
+cp src/theme/SearchBar/*.css dist/theme/SearchBar

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -41,7 +41,7 @@ export default function OramaPluginDocusaurus(
     name: "@orama/plugin-docusaurus-v3",
 
     getThemePath() {
-      return "../lib/theme"
+      return "../dist/theme"
     },
 
     getTypeScriptThemePath() {
@@ -49,7 +49,7 @@ export default function OramaPluginDocusaurus(
     },
 
     getClientModules() {
-      return ["../lib/theme/SearchBar/index.css"]
+      return ["../dist/theme/SearchBar/index.css"]
     },
 
     async allContentLoaded({ actions, allContent }) {

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -133,16 +133,20 @@ export default function OramaPluginDocusaurus(
         }
       })
 
-      const oramaDocs = (await Promise.all(allOramaDocsPromises)).flat().filter(data => !!data.content && !!data.title).map((data) => {
-        return ({
-          title: data.title,
-          content: data.content,
-          section: data.originalTitle,
-          version: data.version,
-          path: data.path,
-          category: data.category
-        })
-      })
+      const oramaDocs = (await Promise.all(allOramaDocsPromises)).flat().reduce((acc, curr) => {
+        if (!!curr.title && !!curr.content) {
+          acc.push({
+            title: curr.title,
+            content: curr.content,
+            section: curr.originalTitle,
+            version: curr.version,
+            path: curr.path,
+            category: curr.category
+          })
+        }
+
+        return acc
+      }, [])
 
       if (isDevelopment) {
         actions.setGlobalData({

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -1,15 +1,15 @@
-import { readFileSync, writeFileSync } from 'node:fs'
-import type { Plugin } from '@docusaurus/types'
-import { cp } from 'node:fs/promises'
-import { gzip } from 'pako'
-import { resolve } from 'node:path'
+import { readFileSync, writeFileSync } from "node:fs"
+import type { Plugin } from "@docusaurus/types"
+import { cp } from "node:fs/promises"
+import { gzip } from "pako"
+import { resolve } from "node:path"
 // @ts-ignore
-import { presets } from '@orama/searchbox'
-import { create, insertMultiple, save } from '@orama/orama'
-import { JSDOM } from 'jsdom'
-import MarkdownIt from 'markdown-it'
-import matter from 'gray-matter'
-import { createSnapshot, deployIndex, fetchEndpointConfig } from './utils'
+import { presets } from "@orama/searchbox"
+import { create, insertMultiple, save } from "@orama/orama"
+import { JSDOM } from "jsdom"
+import MarkdownIt from "markdown-it"
+import matter from "gray-matter"
+import { createSnapshot, deployIndex, fetchEndpointConfig } from "./utils"
 
 type CloudConfig = {
   deploy: boolean
@@ -38,33 +38,33 @@ export default function OramaPluginDocusaurus(
   let versions: any[] = []
 
   return {
-    name: '@orama/plugin-docusaurus-v3',
+    name: "@orama/plugin-docusaurus-v3",
 
     getThemePath() {
-      return '../lib/theme'
+      return "../lib/theme"
     },
 
     getTypeScriptThemePath() {
-      return '../src/theme'
+      return "../src/theme"
     },
 
     getClientModules() {
-      return ['../lib/theme/SearchBar/index.css']
+      return ["../lib/theme/SearchBar/index.css"]
     },
 
     async allContentLoaded({ actions, allContent }) {
-      const isDevelopment = process.env.NODE_ENV === 'development'
-      let docsInstances: string[] = []
+      const isDevelopment = process.env.NODE_ENV === "development"
+      const docsInstances: string[] = []
       const oramaCloudAPIKey = options.cloud?.oramaCloudAPIKey
       const searchDataConfig = [
         {
-          docs: allContent['docusaurus-plugin-content-docs']
+          docs: allContent["docusaurus-plugin-content-docs"]
         },
         {
-          blogs: allContent['docusaurus-plugin-content-blog']
+          blogs: allContent["docusaurus-plugin-content-blog"]
         },
         {
-          pages: allContent['docusaurus-plugin-content-pages']
+          pages: allContent["docusaurus-plugin-content-pages"]
         }
       ]
 
@@ -78,7 +78,7 @@ export default function OramaPluginDocusaurus(
       searchDataConfig.forEach((config) => {
         const [key, value] = Object.entries(config)[0]
         switch (key) {
-          case 'docs':
+          case "docs":
             if (!value) break
             Object.keys(value).forEach((docsInstance: any) => {
               const loadedVersions = value?.[docsInstance]?.loadedVersions
@@ -99,60 +99,62 @@ export default function OramaPluginDocusaurus(
               })
             })
             break
-          case 'blogs':
-            const blogsInstances = Object.keys(value)
-            blogsInstances.forEach(async (instance) => {
+          case "blogs":
+            Object.keys(value).forEach(async (instance) => {
               const loadedInstance = value[instance]
               allOramaDocsPromises.push(
                 ...loadedInstance.blogPosts.map(({ metadata }: any) => {
                   return generateDocs({
                     siteDir: ctx.siteDir,
-                    version: 'current',
-                    category: 'blogs',
+                    version: "current",
+                    category: "blogs",
                     data: metadata
                   })
                 })
               )
             })
             break
-          case 'pages':
-            const pagesInstances = Object.keys(value)
-            pagesInstances.forEach(async (instance) => {
+          case "pages":
+            Object.keys(value).forEach(async (instance) => {
               const loadedInstance = value[instance]
               allOramaDocsPromises.push(
                 ...loadedInstance.map((data: any) =>
                   generateDocs({
                     siteDir: ctx.siteDir,
-                    version: 'current',
-                    category: 'pages',
+                    version: "current",
+                    category: "pages",
                     data
                   })
                 )
               )
             })
+
             break
         }
       })
 
-      const oramaDocs = (await Promise.all(allOramaDocsPromises)).flat().map((data) => ({
-        title: data.title,
-        content: data.content,
-        section: data.originalTitle,
-        version: data.version,
-        path: data.path,
-        category: data.category
-      }))
+      const oramaDocs = (await Promise.all(allOramaDocsPromises)).flat().filter(data => !!data.content && !!data.title).map((data) => {
+        return ({
+          title: data.title,
+          content: data.content,
+          section: data.originalTitle,
+          version: data.version,
+          path: data.path,
+          category: data.category
+        })
+      })
+
       const endpointConfig = await deployData({
         oramaDocs,
         generatedFilesDir: ctx.generatedFilesDir,
-        version: 'current',
+        version: "current",
         deployConfig
       })
 
       actions.setGlobalData({
         ...(isDevelopment &&
           !options.cloud && {
-            searchData: Object.fromEntries([['current', readFileSync(indexPath(ctx.generatedFilesDir, 'current'))]])
+            searchData: Object.fromEntries([["current", readFileSync(indexPath(ctx.generatedFilesDir, "current"))]])
           }),
         docsInstances,
         availableVersions: versions,
@@ -167,7 +169,7 @@ export default function OramaPluginDocusaurus(
     },
 
     async postBuild({ outDir }) {
-      !options.cloud && (await cp(indexPath(ctx.generatedFilesDir, 'current'), indexPath(outDir, 'current')))
+      !options.cloud && (await cp(indexPath(ctx.generatedFilesDir, "current"), indexPath(outDir, "current")))
     }
   }
 }
@@ -184,7 +186,7 @@ async function generateDocs({
   data: Record<string, string>
 }) {
   const { title, permalink, source } = data
-  const fileContent = readFileSync(source.replace('@site', siteDir), 'utf-8')
+  const fileContent = readFileSync(source.replace("@site", siteDir), "utf-8")
   const contentWithoutFrontMatter = matter(fileContent).content
 
   return parseHTMLContent({
@@ -221,12 +223,12 @@ function parseHTMLContent({
     path: any
   }[] = []
 
-  const headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6')
+  const headers = document.querySelectorAll("h1, h2, h3, h4, h5, h6")
   if (!headers.length) {
     sections.push({
       originalTitle,
       title: originalTitle,
-      header: 'h1',
+      header: "h1",
       content: html,
       version,
       category,
@@ -236,17 +238,17 @@ function parseHTMLContent({
   headers.forEach((header) => {
     const sectionTitle = header.textContent?.trim()
     const headerTag = header.tagName.toLowerCase()
-    let sectionContent = ''
+    let sectionContent = ""
 
     let sibling = header.nextElementSibling
-    while (sibling && !['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(sibling.tagName)) {
-      sectionContent += sibling.textContent?.trim() + '\n'
+    while (sibling && !["H1", "H2", "H3", "H4", "H5", "H6"].includes(sibling.tagName)) {
+      sectionContent += sibling.textContent?.trim() + "\n"
       sibling = sibling.nextElementSibling
     }
 
     sections.push({
       originalTitle,
-      title: sectionTitle ?? '',
+      title: sectionTitle ?? "",
       header: headerTag,
       content: sectionContent,
       version,
@@ -259,7 +261,7 @@ function parseHTMLContent({
 }
 
 function indexPath(outDir: string, version: string) {
-  return resolve(outDir, 'orama-search-index-@VERSION@.json.gz'.replace('@VERSION@', version))
+  return resolve(outDir, "orama-search-index-@VERSION@.json.gz".replace("@VERSION@", version))
 }
 
 async function deployData({
@@ -273,14 +275,14 @@ async function deployData({
   version: string
   deployConfig:
     | {
-        indexId: string
-        enabled: boolean
-        oramaCloudAPIKey: string | undefined
-      }
+    indexId: string
+    enabled: boolean
+    oramaCloudAPIKey: string | undefined
+  }
     | undefined
 }) {
   const { ORAMA_CLOUD_BASE_URL } = process.env
-  const baseUrl = ORAMA_CLOUD_BASE_URL || 'https://cloud.oramasearch.com'
+  const baseUrl = ORAMA_CLOUD_BASE_URL || "https://cloud.oramasearch.com"
 
   if (deployConfig) {
     const endpointConfig = await fetchEndpointConfig(baseUrl, deployConfig.oramaCloudAPIKey!, deployConfig.indexId!)
@@ -293,7 +295,7 @@ async function deployData({
     return endpointConfig
   } else {
     const db = await create({
-      schema: { ...presets.docs.schema, version: 'enum' }
+      schema: { ...presets.docs.schema, version: "enum" }
     })
 
     await insertMultiple(db, oramaDocs as any)

--- a/packages/plugin-docusaurus-v3/tsconfig.json
+++ b/packages/plugin-docusaurus-v3/tsconfig.json
@@ -31,7 +31,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
 
-    "outDir": "lib"
+    "outDir": "dist"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Description
This PR's scope is to remove the _untitled_ and _empty content_ docs/pages/blogs from the final docs list.

### Main changes
- filter docs removing empty values
- can run locally without passing API KEY (nor removing the config under `docusaurus.config.js`)
- move `lib` to `dist`