### PR TITLE
docs(plugin-docusaurus-v3):  detail for deploy type

### DIFF
--- a/packages/docs/src/content/docs/open-source/plugins/plugin-docusaurus.mdx
+++ b/packages/docs/src/content/docs/open-source/plugins/plugin-docusaurus.mdx
@@ -52,13 +52,15 @@ plugins: [
       cloud: {
         indexId: "<your_orama_index_id>",
         oramaCloudAPIKey: process.env.ORAMA_CLOUD_API_KEY, // Env variable suggested
-        deploy: true, // Enables deploy while building/starting
+        deploy: false | "default" | "snapshot-only", // Enables deploy while building/starting
       },
     },
   ],
 ];
 // ...
 ```
+
+Make sure you use the correct deploy configuration. Failure to do so will result in compilation failure. see [DelopyType](https://github.com/askorama/orama/blob/77ba63c654068ef718bc84604e11e57dafd7a4d4/packages/plugin-docusaurus-v3/src/index.ts#L14). 
 
 To get this variables first create a new integration for HTTP Integrations in here:
 


### PR DESCRIPTION
The deploy configuration in the initial example of the documentation is true. will cause the user to copy directly and cause the compilation to fail. Adding a configuration type enumeration and a link to the relevant type will help users use the deploy type more quickly.

![image](https://github.com/user-attachments/assets/ed729b76-6ad4-4e66-939b-1cff9a164a79)
![image](https://github.com/user-attachments/assets/b1982fb8-64c7-4438-80aa-7beeb3d79b42)


The recommended initial configuration can be changed to default
