### PR TITLE
Fix issues with `plugin-docusaurus-v3` detecting local mode.

### DIFF
--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -58,7 +58,7 @@ export default function OramaPluginDocusaurus(
     },
 
     async allContentLoaded({ actions, allContent }) {
-      const isDevelopment = process.env.NODE_ENV === 'development' || !options.cloud?.oramaCloudAPIKey
+      const isDevelopment = process.env.NODE_ENV === 'development' || (options.cloud && !options.cloud?.oramaCloudAPIKey)
       const docsInstances: string[] = []
       const oramaCloudAPIKey = options.cloud?.oramaCloudAPIKey
       const searchDataConfig = [

--- a/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
+++ b/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
@@ -20,7 +20,7 @@ export const useOrama = () => {
   const isBrowser = useIsBrowser()
   useEffect(() => {
     async function loadOrama() {
-      if (endpoint) {
+      if (endpoint?.url) {
         setSearchBoxConfig({
           oramaInstance: new OramaClient({
             endpoint: endpoint.url,


### PR DESCRIPTION
Fixes #728. 

Now on a fresh docusaurus install running `npm run build` then `npm run start` or `npm run serve` should display results correctly.