### PR TITLE
feat: generate embeddings on insert via Secure Proxy plugin

### DIFF
--- a/packages/plugin-secure-proxy/README.md
+++ b/packages/plugin-secure-proxy/README.md
@@ -22,11 +22,18 @@ const db = await create({
   },
   plugins: [
     pluginSecureProxy({
-      apiKey: '<API-KEY>',
-      defaultProperty: 'embeddings',
-      models: {
-        embeddings: 'orama/gte-small',
-        chat: 'openai/gpt-4o' // chat model is optional
+      apiKey: 'xyz',
+      embeddings: {
+        defaultProperty: 'embeddings',
+        model: 'orama/gte-small',
+        onInsert: {
+          generate: true, // Generate the embeddings at insert-time
+          properties: ['title', 'description'], // Properties to generate embeddings from
+          verbose: false
+        },
+      },
+      chat: {
+        model: 'openai/gpt-4o'
       }
     })
   ]

--- a/packages/plugin-secure-proxy/src/index.ts
+++ b/packages/plugin-secure-proxy/src/index.ts
@@ -8,20 +8,6 @@ export type SecureProxyExtra = {
 
 export type LLMModel = ChatModel
 
-// export type SecureProxyPluginOptions = {
-//   apiKey: string
-//   defaultProperty: string
-//   models: {
-//     embeddings: EmbeddingModel
-//     chat?: LLMModel
-//   }
-//   embeddingsConfig?: {
-//     generate: boolean
-//     properties: string[]
-//     verbose?: boolean
-//   }
-// }
-
 export type SecureProxyPluginOptions = {
   apiKey: string
   embeddings: {

--- a/packages/plugin-secure-proxy/src/index.ts
+++ b/packages/plugin-secure-proxy/src/index.ts
@@ -35,7 +35,7 @@ function getPropertiesValues(schema: object, properties: string[]) {
   return properties
     .map(prop => getPropertyValue(schema, prop))
     .filter(value => value !== undefined)
-    .join('.')
+    .join('. ')
 }
 
 export function pluginSecureProxy(pluginParams: SecureProxyPluginOptions): OramaPluginSync<SecureProxyExtra> {
@@ -54,7 +54,7 @@ export function pluginSecureProxy(pluginParams: SecureProxyPluginOptions): Orama
       pluginParams
     },
 
-    async beforeInsert<T extends TypedDocument<any>>(db: AnyOrama, params: PartialSchemaDeep<T>) {
+    async beforeInsert<T extends TypedDocument<any>>(_db: AnyOrama, _id: string, params: PartialSchemaDeep<T>) {
       if (!pluginParams.embeddings?.onInsert?.generate) {
         return
       }

--- a/packages/plugin-secure-proxy/src/index.ts
+++ b/packages/plugin-secure-proxy/src/index.ts
@@ -33,7 +33,7 @@ function getPropertiesValues(schema: object, properties: string[]) {
   return properties
     .map(prop => getPropertyValue(schema, prop))
     .filter(value => value !== undefined)
-    .join(' ');
+    .join('.');
 }
 
 export function pluginSecureProxy(pluginParams: SecureProxyPluginOptions): OramaPluginSync<SecureProxyExtra> {
@@ -65,7 +65,7 @@ export function pluginSecureProxy(pluginParams: SecureProxyPluginOptions): Orama
       const values = getPropertiesValues(params, properties)
 
       if (pluginParams.embeddingsConfig?.verbose) {
-        console.log(`Generating embeddings for properties: ${properties.join(', ')}: ${values}`)
+        console.log(`Generating embeddings for properties ${properties.join(', ')}: ${values}`)
       }
 
       const embeddings = await proxy.generateEmbeddings(values, pluginParams.models.embeddings)

--- a/packages/plugin-secure-proxy/src/index.ts
+++ b/packages/plugin-secure-proxy/src/index.ts
@@ -27,7 +27,7 @@ export type SecureProxyPluginOptions = {
 function getPropertyValue (obj: object, path: string) {
   return path.split('.').reduce((current, key) => 
     current && current[key] !== undefined ? current[key] : undefined, obj
-  );
+  )
 }
 
 
@@ -35,7 +35,7 @@ function getPropertiesValues(schema: object, properties: string[]) {
   return properties
     .map(prop => getPropertyValue(schema, prop))
     .filter(value => value !== undefined)
-    .join('.');
+    .join('.')
 }
 
 export function pluginSecureProxy(pluginParams: SecureProxyPluginOptions): OramaPluginSync<SecureProxyExtra> {


### PR DESCRIPTION
With this PR, Orama OSS will be able to generate embeddings at insert-time via the Secure Proxy plugin.

```js
import { create, insert } from '@orama/orama'
import { pluginSecureProxy } from '@orama/plugin-secure-proxy'

const secureProxy = pluginSecureProxy({
  apiKey: 'xyz',
  embeddings: {
    defaultProperty: 'embeddings',
    model: 'orama/gte-small',
    onInsert: {
      generate: true, // Generate the embeddings at insert-time
      properties: ['name', 'data.age'],
      verbose: true
    },
  },
  chat: {
    model: 'openai/gpt-4o'
  }
})

const db = await create({
  schema: {
    name: 'string',
    data: {
      age: 'number'
    },
    embeddings: 'vector[384]'
  },
  plugins: [secureProxy]
})

await insert(db, { name: 'Michele', age: 29 })
// since "verbose" is set to `true`, it will log:
// Generating embeddings for properties name, data.age : "Michele. 29."
```