### PR TITLE
feat: adds new package (Orama Switch)

### DIFF
--- a/packages/switch/LICENSE.md
+++ b/packages/switch/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2024 OramaSearch Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -15,7 +15,7 @@ You can use the same APIs to access either Orama Cloud or Orama OSS.
 For instance, this is how you would interact with Orama Cloud:
 
 ```js
-import { switch } from '@orama/switch'
+import { Switch } from '@orama/switch'
 import { OramaClient } from '@oramacloud/client'
 
 const client = new OramaClient({
@@ -23,7 +23,7 @@ const client = new OramaClient({
   api_key: '<Your Orama Cloud API Key>',
 })
 
-const orama = switch(client)
+const orama = new Switch(client)
 
 const results = await orama.search({
   term: 'noise cancelling headphones',
@@ -38,7 +38,7 @@ const results = await orama.search({
 And this is Orama OSS:
 
 ```js
-import { switch } from '@orama/switch'
+import { Switch } from '@orama/switch'
 import { create } from '@orama/orama'
 
 const db = await create({
@@ -48,7 +48,7 @@ const db = await create({
   }
 })
 
-const orama = switch(db)
+const orama = new Switch(client)
 
 const results = await orama.search({
   term: 'noise cancelling headphones',

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -1,0 +1,65 @@
+# Orama Switch
+
+Orama Switch allows you to run queries on Orama Cloud and OSS with a single interface.
+
+## Installation
+
+```sh
+npm i @orama/switch
+```
+
+## Usage
+
+You can use the same APIs to access either Orama Cloud or Orama OSS.
+
+For instance, this is how you would interact with Orama Cloud:
+
+```js
+import { switch } from '@orama/switch'
+import { OramaClient } from '@oramacloud/client'
+
+const client = new OramaClient({
+  endpoint: '<Your Orama Cloud Endpoint>',
+  api_key: '<Your Orama Cloud API Key>',
+})
+
+const orama = switch(client)
+
+const results = await orama.search({
+  term: 'noise cancelling headphones',
+  where: {
+    price: {
+      lte: 99.99
+    }
+  }
+})
+```
+
+And this is Orama OSS:
+
+```js
+import { switch } from '@orama/switch'
+import { create } from '@orama/orama'
+
+const db = await create({
+  schema: {
+    productName: 'string',
+    price: 'number'
+  }
+})
+
+const orama = switch(db)
+
+const results = await orama.search({
+  term: 'noise cancelling headphones',
+  where: {
+    price: {
+      lte: 99.99
+    }
+  }
+})
+```
+
+## License
+
+[Apache 2.0](/LICENSE.md)

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -2,18 +2,39 @@
   "name": "@orama/switch",
   "version": "2.0.24",
   "description": "Orama Switch allows you to run queries on Orama Cloud and OSS with a single interface",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "node": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "tsup"
   },
   "keywords": [
     "orama",
     "orama cloud"
   ],
+  "type": "module",
   "author": {
     "name": "Michele Riva",
     "email": "michele@orama.com",
     "url": "https://github.com/micheleriva"
   },
-  "license": "Apache-2.0"
+  "peerDependencies": {
+    "@orama/orama": "workspace:*",
+    "@oramacloud/client": "1.3.15"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "tsup": "^7.2.0"
+  }
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@orama/switch",
+  "version": "2.0.24",
+  "description": "Orama Switch allows you to run queries on Orama Cloud and OSS with a single interface",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "orama",
+    "orama cloud"
+  ],
+  "author": {
+    "name": "Michele Riva",
+    "email": "michele@orama.com",
+    "url": "https://github.com/micheleriva"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/switch/src/index.ts
+++ b/packages/switch/src/index.ts
@@ -1,0 +1,36 @@
+import type { AnyOrama, Results, SearchParams, Nullable } from '@orama/orama'
+import { search } from '@orama/orama'
+import { OramaClient, ClientSearchParams } from '@oramacloud/client'
+
+type OramaSwitchClient = AnyOrama | OramaClient
+
+type ClientType = 'oss' | 'cloud'
+
+export class Switch<T = OramaSwitchClient> {
+  client: OramaSwitchClient
+  clientType: ClientType
+  isCloud: boolean = false
+  isOSS: boolean = false
+  
+  constructor(client: OramaSwitchClient) {
+    this.client = client
+
+    if (client instanceof OramaClient) {
+      this.clientType = 'cloud'
+      this.isCloud = true
+    } else if (typeof client === 'object' && 'id' in client && 'tokenizer' in client) {
+      this.clientType = 'oss'
+      this.isOSS = true
+    } else {
+      throw new Error('Invalid client. Expected either an OramaClient or an Orama OSS database.')
+    }
+  }
+
+  async search<R = unknown>(params: T extends OramaClient ? ClientSearchParams : SearchParams<AnyOrama>): Promise<Nullable<Results<R>>> {
+    if (this.isCloud) {
+      return (this.client as OramaClient).search(params as T extends OramaClient ? ClientSearchParams : never)
+    } else {
+      return search(this.client as AnyOrama, params as SearchParams<AnyOrama>) as Promise<Nullable<Results<R>>>
+    }
+  }
+}

--- a/packages/switch/tsconfig.json
+++ b/packages/switch/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "outDir": "dist",
+    "lib": ["ESNext", "DOM"],
+    "esModuleInterop": true,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/*.ts", "src/**/*.ts"]
+}

--- a/packages/switch/tsup.config.ts
+++ b/packages/switch/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: true,
+  sourcemap: true,
+  clean: true,
+  bundle: true,
+  dts: true,
+  minify: false,
+  format: ['cjs', 'esm', 'iife'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -747,7 +747,7 @@ importers:
         version: link:../plugin-data-persistence
       '@orama/searchbox':
         specifier: 1.0.0-beta.13
-        version: 1.0.0-beta.13(@orama/highlight@0.1.6)(@orama/orama@packages+orama)(@oramacloud/client@1.3.14(encoding@0.1.13)(typescript@5.2.2))(@preact/signals-core@1.5.0)(@preact/signals@1.2.2(preact@10.19.2))(postcss@8.4.38)(preact-custom-element@4.3.0(preact@10.19.2))(preact@10.19.2)
+        version: 1.0.0-beta.13(@orama/highlight@0.1.6)(@orama/orama@packages+orama)(@oramacloud/client@1.3.15(encoding@0.1.13)(typescript@5.2.2))(@preact/signals-core@1.5.0)(@preact/signals@1.2.2(preact@10.19.2))(postcss@8.4.38)(preact-custom-element@4.3.0(preact@10.19.2))(preact@10.19.2)
       '@vitejs/plugin-vue':
         specifier: ^4.5.1
         version: 4.5.1(vite@4.5.3(@types/node@20.11.19)(terser@5.17.7))(vue@3.3.10(typescript@5.2.2))
@@ -800,6 +800,19 @@ importers:
       '@swc/core':
         specifier: ^1.3.27
         version: 1.3.27
+
+  packages/switch:
+    dependencies:
+      '@orama/orama':
+        specifier: workspace:*
+        version: link:../orama
+      '@oramacloud/client':
+        specifier: 1.3.15
+        version: 1.3.15(encoding@0.1.13)(typescript@5.5.2)
+    devDependencies:
+      tsup:
+        specifier: ^7.2.0
+        version: 7.2.0(@swc/core@1.3.27)(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.9.0)(typescript@5.5.2))(typescript@5.5.2)
 
   packages/tokenizers:
     dependencies:
@@ -4151,6 +4164,9 @@ packages:
 
   '@oramacloud/client@1.3.14':
     resolution: {integrity: sha512-lD8i0+52W+RX5mDVfEEEdp38NvVCi5fX7GHLUlVTkKGnb5W8u2lEJlYnVhq9Lt0A5Qs3T9NYIczgTvUzD3jzpA==}
+
+  '@oramacloud/client@1.3.15':
+    resolution: {integrity: sha512-QBgQrK0WA9pPzeVh/E6p44erwL0IJaHB3TrbEAsrduqbj38xY06jjpYsn//2fJt34jEnIBjOwPkjZ3OJEJlR4A==}
 
   '@pagefind/darwin-arm64@1.1.0':
     resolution: {integrity: sha512-SLsXNLtSilGZjvqis8sX42fBWsWAVkcDh1oerxwqbac84HbiwxpxOC2jm8hRwcR0Z55HPZPWO77XeRix/8GwTg==}
@@ -16401,7 +16417,7 @@ snapshots:
       '@types/node': 20.11.19
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@20.11.19)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.11.19)(typescript@5.5.2))(typescript@5.5.2)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@20.11.19)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@18.11.18)(typescript@5.0.3))(typescript@5.5.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -16421,7 +16437,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.2.0
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@20.5.1)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.5.1)(typescript@5.5.2))(typescript@5.5.2)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@20.5.1)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.9.0)(typescript@5.0.3))(typescript@5.5.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -16622,7 +16638,7 @@ snapshots:
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.27)(webpack@5.89.0(@swc/core@1.3.27))
       tslib: 2.6.2
       update-notifier: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       wait-on: 6.0.1
       webpack: 5.89.0(@swc/core@1.3.27)
       webpack-bundle-analyzer: 4.9.0
@@ -16715,7 +16731,7 @@ snapshots:
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.27)(webpack@5.89.0(@swc/core@1.3.27))
       tslib: 2.6.2
       update-notifier: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       wait-on: 6.0.1
       webpack: 5.89.0(@swc/core@1.3.27)
       webpack-bundle-analyzer: 4.9.0
@@ -16807,7 +16823,7 @@ snapshots:
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.27)(webpack@5.89.0(@swc/core@1.3.27))
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
       webpack-bundle-analyzer: 4.9.0
       webpack-dev-server: 4.15.1(webpack@5.89.0(@swc/core@1.3.27))
@@ -16899,7 +16915,7 @@ snapshots:
       terser-webpack-plugin: 5.3.9(@swc/core@1.3.27)(webpack@5.89.0(@swc/core@1.3.27))
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
       webpack-bundle-analyzer: 4.9.0
       webpack-dev-server: 4.15.1(webpack@5.89.0(@swc/core@1.3.27))
@@ -16978,7 +16994,7 @@ snapshots:
       tslib: 2.6.2
       unified: 9.2.2
       unist-util-visit: 2.0.3
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -17015,7 +17031,7 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       vfile: 6.0.1
       webpack: 5.89.0(@swc/core@1.3.27)
     transitivePeerDependencies:
@@ -17051,7 +17067,7 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       vfile: 6.0.1
       webpack: 5.89.0(@swc/core@1.3.27)
     transitivePeerDependencies:
@@ -18355,7 +18371,7 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
     optionalDependencies:
       '@docusaurus/types': 2.4.3(@swc/core@1.3.27)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -18383,7 +18399,7 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
     optionalDependencies:
       '@docusaurus/types': 3.0.1(@swc/core@1.3.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -18413,7 +18429,7 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27))
       webpack: 5.89.0(@swc/core@1.3.27)
     optionalDependencies:
       '@docusaurus/types': 3.2.0(@swc/core@1.3.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -19372,12 +19388,12 @@ snapshots:
       - encoding
       - typescript
 
-  '@orama/searchbox@1.0.0-beta.13(@orama/highlight@0.1.6)(@orama/orama@packages+orama)(@oramacloud/client@1.3.14(encoding@0.1.13)(typescript@5.2.2))(@preact/signals-core@1.5.0)(@preact/signals@1.2.2(preact@10.19.2))(postcss@8.4.38)(preact-custom-element@4.3.0(preact@10.19.2))(preact@10.19.2)':
+  '@orama/searchbox@1.0.0-beta.13(@orama/highlight@0.1.6)(@orama/orama@packages+orama)(@oramacloud/client@1.3.15(encoding@0.1.13)(typescript@5.2.2))(@preact/signals-core@1.5.0)(@preact/signals@1.2.2(preact@10.19.2))(postcss@8.4.38)(preact-custom-element@4.3.0(preact@10.19.2))(preact@10.19.2)':
     dependencies:
       '@orama/highlight': 0.1.6
       '@orama/orama': link:packages/orama
       '@orama/plugin-analytics': 2.0.20
-      '@oramacloud/client': 1.3.14(encoding@0.1.13)(typescript@5.2.2)
+      '@oramacloud/client': 1.3.15(encoding@0.1.13)(typescript@5.2.2)
       '@preact/signals': 1.2.2(preact@10.19.2)
       '@preact/signals-core': 1.5.0
       object-to-css-variables: 0.2.1
@@ -19462,7 +19478,19 @@ snapshots:
       - encoding
       - typescript
 
-  '@oramacloud/client@1.3.14(encoding@0.1.13)(typescript@5.2.2)':
+  '@oramacloud/client@1.3.14(encoding@0.1.13)(typescript@5.5.2)':
+    dependencies:
+      '@orama/orama': 2.0.23
+      '@paralleldrive/cuid2': 2.2.2
+      lodash: 4.17.21
+      openai: 4.52.0(encoding@0.1.13)
+      react: 18.3.1
+      vue: 3.4.29(typescript@5.5.2)
+    transitivePeerDependencies:
+      - encoding
+      - typescript
+
+  '@oramacloud/client@1.3.15(encoding@0.1.13)(typescript@5.2.2)':
     dependencies:
       '@orama/orama': 2.0.23
       '@paralleldrive/cuid2': 2.2.2
@@ -19474,7 +19502,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@oramacloud/client@1.3.14(encoding@0.1.13)(typescript@5.5.2)':
+  '@oramacloud/client@1.3.15(encoding@0.1.13)(typescript@5.5.2)':
     dependencies:
       '@orama/orama': 2.0.23
       '@paralleldrive/cuid2': 2.2.2
@@ -23005,14 +23033,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@20.11.19)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.11.19)(typescript@5.5.2))(typescript@5.5.2):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@20.11.19)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@18.11.18)(typescript@5.0.3))(typescript@5.5.2):
     dependencies:
       '@types/node': 20.11.19
       cosmiconfig: 8.2.0
       ts-node: 10.9.1(@swc/core@1.3.27)(@types/node@20.11.19)(typescript@5.5.2)
       typescript: 5.5.2
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@20.5.1)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.5.1)(typescript@5.5.2))(typescript@5.5.2):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@20.5.1)(cosmiconfig@8.2.0)(ts-node@10.9.1(@swc/core@1.3.27)(@types/node@20.9.0)(typescript@5.0.3))(typescript@5.5.2):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.2.0
@@ -32175,7 +32203,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.75.0(@swc/core@1.3.27)))(webpack@5.89.0(@swc/core@1.3.27)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35


### PR DESCRIPTION
With Orama Switch, you can use the same APIs to access either Orama Cloud or Orama OSS.

For instance, this is how you would interact with Orama Cloud:

```js
import { Switch } from '@orama/switch'
import { OramaClient } from '@oramacloud/client'

const client = new OramaClient({
  endpoint: '<Your Orama Cloud Endpoint>',
  api_key: '<Your Orama Cloud API Key>',
})

const orama = new Switch(client)

const results = await orama.search({
  term: 'noise cancelling headphones',
  where: {
    price: {
      lte: 99.99
    }
  }
})
```

And this is Orama OSS:

```js
import { Switch } from '@orama/switch'
import { create } from '@orama/orama'

const db = await create({
  schema: {
    productName: 'string',
    price: 'number'
  }
})

const orama = new Switch(client)

const results = await orama.search({
  term: 'noise cancelling headphones',
  where: {
    price: {
      lte: 99.99
    }
  }
})
```