### PR TITLE
Implement kushuh's change preventing div by zero in removeDocumentScoreParameters

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -162,8 +162,11 @@ export async function removeDocumentScoreParameters(
 ): Promise<void> {
   const internalId = getInternalDocumentId(index.sharedInternalDocumentStore, id)
 
-  index.avgFieldLength[prop] =
-    (index.avgFieldLength[prop] * docsCount - index.fieldLengths[prop][internalId]!) / (docsCount - 1)
+  if (docsCount > 1) {
+    index.avgFieldLength[prop] = (index.avgFieldLength[prop] * docsCount - index.fieldLengths[prop][internalId]!) / (docsCount - 1);
+  } else {
+    index.avgFieldLength[prop] = undefined;
+  }
   index.fieldLengths[prop][internalId] = undefined
   index.frequencies[prop][internalId] = undefined
 }


### PR DESCRIPTION
Implement @kushuh's proposed change in #766 , modifying removeDocumentScoreParameters to check for a divide by zero scenario before doing the calculation.

Sorry to snipe this change; just needed it badly, haha!