### PR TITLE
fix: fixes zero division when computing scores after removing all documents from an index

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -165,7 +165,7 @@ export async function removeDocumentScoreParameters(
   if (docsCount > 1) {
     index.avgFieldLength[prop] = (index.avgFieldLength[prop] * docsCount - index.fieldLengths[prop][internalId]!) / (docsCount - 1);
   } else {
-    index.avgFieldLength[prop] = undefined;
+    index.avgFieldLength[prop] = undefined as unknown as number;
   }
   index.fieldLengths[prop][internalId] = undefined
   index.frequencies[prop][internalId] = undefined

--- a/packages/orama/tests/remove.test.ts
+++ b/packages/orama/tests/remove.test.ts
@@ -353,3 +353,20 @@ async function createSimpleDB() {
 
   return [db, id1, id2, id3, id4] as const
 }
+
+t.test('test case for #766: Zero division when computing scores after removing all documents from an index.', async (t) => {
+  const db = await create({
+    schema: {
+      name: 'string'
+    } as const
+  })
+
+  const id = await insert(db, { name: 'test' })
+
+  const success = await remove(db, id)
+
+  await insert(db, { name: 'foo' })
+  await insert(db, { name: 'bar' })
+
+  t.ok(success)
+})


### PR DESCRIPTION
@AdventureBeard I'm making a release today so I'm opening a PR to speed this up!