### PR TITLE
docs: fix broken links

### DIFF
--- a/packages/docs/src/content/docs/cloud/orama-ai/orama-secure-proxy.mdx
+++ b/packages/docs/src/content/docs/cloud/orama-ai/orama-secure-proxy.mdx
@@ -4,7 +4,7 @@ description: Learn how to use the Orama Secure Proxy to safely call OpenAI APIs 
 editUrl: false
 ---
 
-When running a [vector](/open-source/usage/search/vector-search.html) or [hybrid](/open-source/usage/search/hybrid-search.html) search with Orama (or any other vector database), there is a process called **inference**.
+When running a [vector](/open-source/usage/search/vector-search) or [hybrid](/open-source/usage/search/hybrid-search) search with Orama (or any other vector database), there is a process called **inference**.
 
 This term refers to the process of using a trained machine learning model to make predictions on new, unseen data. In the context of a vector or hybrid search, this could involve using the model to transform raw data into a vector representation that can then be used in the search process.
 
@@ -18,7 +18,7 @@ Because Orama is a vector database that operates client-side, we offer a secure 
 
 The **Orama Secure Proxy** is available with the free plan of Orama Cloud. Before you start, make sure to [create a free account](https://cloud.orama.com) (no credit card required).
 
-Navigating to [https://cloud.orama.com/secure-proxy](https://cloud.orama.com/secure-proxy), you will notice that you'll need to import an OpenAI API Key before you start. This is required for other services too (such as the [automatic embeddings generation](/cloud/orama-ai/automatic-embeddings-generation.html)). Orama will encrypt this information in a secure vault and will never be able to retrieve it again in plaintext.
+Navigating to [https://cloud.orama.com/secure-proxy](https://cloud.orama.com/secure-proxy), you will notice that you'll need to import an OpenAI API Key before you start. This is required for other services too (such as the [automatic embeddings generation](/cloud/orama-ai/automatic-embeddings-generation)). Orama will encrypt this information in a secure vault and will never be able to retrieve it again in plaintext.
 
 <img
   src='/plugins/secure-proxy/initial-screen.png'
@@ -89,7 +89,7 @@ By selecting the "Encrypt chat messages" option, the Secure Proxy will provide e
 
 The Secure Proxy can be used in two ways:
 
-1. Using the `@orama/plugin-secure-proxy` npm package (see [the official plugin documentation](/open-source/plugins/plugin-secure-proxy.html) for details). This will allow you to perform hybrid and vector search with your Orama OSS instance with very little configuration.
+1. Using the `@orama/plugin-secure-proxy` npm package (see [the official plugin documentation](/open-source/plugins/plugin-secure-proxy) for details). This will allow you to perform hybrid and vector search with your Orama OSS instance with very little configuration.
 2. Using the `@oramacloud/client` npm package.
 
 By utilizing the `@oramacloud/client` npm package, you can generate embeddings and interact with OpenAI's GPT browser models without exposing your OpenAI API key or prompts to your users.

--- a/packages/docs/src/content/docs/open-source/plugins/plugin-secure-proxy.mdx
+++ b/packages/docs/src/content/docs/open-source/plugins/plugin-secure-proxy.mdx
@@ -10,7 +10,7 @@ import Install from '../../../../components/Install.astro'
 The **Orama Secure Proxy** plugin is an official Orama plugin that allows you to perform vector and hybrid search securely on your browser by masking OpenAI (and other services soon) API keys when generating embeddings.
 
 <Aside type="note" title='You will need a free Orama Cloud account for this'>
-To use this plugin, you will need a free [Orama Cloud](https://cloud.orama.com) account. If you already have one, follow the [guide](/cloud/orama-ai/orama-secure-proxy.html) to enable the Orama Secure Proxy before continuing.
+To use this plugin, you will need a free [Orama Cloud](https://cloud.orama.com) account. If you already have one, follow the [guide](/cloud/orama-ai/orama-secure-proxy) to enable the Orama Secure Proxy before continuing.
 </Aside>
 
 ## Installation

--- a/packages/docs/src/content/docs/open-source/supported-languages/index.mdx
+++ b/packages/docs/src/content/docs/open-source/supported-languages/index.mdx
@@ -13,7 +13,7 @@ At the time of writing, Chinese (Mandarin) and Japanese are the only exception, 
 
 Since Chinese and Japanese logograms follow different rules than other alphabets, you will need to import a dedicated tokenizer for it.
 
-Read more here about Chinese [here](/open-source/supported-languages/using-chinese-with-orama.html) and about Japanese [here](/open-source/supported-languages/using-japanese-with-orama.html).
+Read more here about Chinese [here](/open-source/supported-languages/using-chinese-with-orama) and about Japanese [here](/open-source/supported-languages/using-japanese-with-orama).
 </Aside>
 
 

--- a/packages/docs/src/content/docs/open-source/usage/search/hybrid-search.mdx
+++ b/packages/docs/src/content/docs/open-source/usage/search/hybrid-search.mdx
@@ -14,7 +14,7 @@ Running hybrid search on the front-end requires a translation from text to vecto
 
 If you're using systems such as OpenAI to generate text embeddings, this would put you at risk of exposing your API Keys.
 
-We highly recommend using the [Orama Secure Proxy Plugin](/open-source/plugins/plugin-secure-proxy.html) to mask your API Keys securely and prevent abuse of any kind.
+We highly recommend using the [Orama Secure Proxy Plugin](/open-source/plugins/plugin-secure-proxy) to mask your API Keys securely and prevent abuse of any kind.
 </Aside>
 
 ## Performing Hybrid Search
@@ -77,7 +77,7 @@ const results = await search(db, {
 
 The plugin will automatically convert this text to vector for you, and will also prevent you from exposing your OpenAI API key when using it on the front-end.
 
-[Learn more](/open-source/plugins/plugin-secure-proxy.html).
+[Learn more](/open-source/plugins/plugin-secure-proxy).
 </Aside>
 
 The returning object will be exactly the same as the one we would expect when performing full-text search:

--- a/packages/docs/src/content/docs/open-source/usage/search/vector-search.mdx
+++ b/packages/docs/src/content/docs/open-source/usage/search/vector-search.mdx
@@ -14,7 +14,7 @@ Running hybrid search on the front-end requires a translation from text to vecto
 
 If you're using systems such as OpenAI to generate text embeddings, this would put you at risk of exposing your API Keys.
 
-We highly recommend using the [Orama Secure Proxy Plugin](/open-source/plugins/plugin-secure-proxy.html) to mask your API Keys securely and prevent abuse of any kind.
+We highly recommend using the [Orama Secure Proxy Plugin](/open-source/plugins/plugin-secure-proxy) to mask your API Keys securely and prevent abuse of any kind.
 </Aside>
 
 ## Performing Vector Search
@@ -83,7 +83,7 @@ const results = await search(db, {
 
 The plugin will automatically convert this text to vector for you, and will also prevent you from exposing your OpenAI API key when using it on the front-end.
 
-[Learn more](/open-source/plugins/plugin-secure-proxy.html).
+[Learn more](/open-source/plugins/plugin-secure-proxy).
 </Aside>
 
 The returning object will be exactly the same as the one we would expect when performing full-text search:


### PR DESCRIPTION
fix: remove `.html` from links