### PR TITLE
docs: fixes typos

### DIFF
--- a/packages/docs/src/content/docs/cloud/performing-search/index.mdx
+++ b/packages/docs/src/content/docs/cloud/performing-search/index.mdx
@@ -7,7 +7,7 @@ import { Aside } from '@astrojs/starlight/components';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import Install from '../../../../components/Install.astro'
 
-Once your data is imported and your index is up and running, you can start performing search queries using one our Official SDKs. Orama offers SDKs for [JavaScript](/cloud/integrating-orama-cloud/official-sdk), [Swift](/cloud/integrating-orama-cloud/official-sdk), [Kotlin](/cloud/integrating-orama-cloud/official-sdk), [PHP](/cloud/integrating-orama-cloud/official-sdk) and [Python](/cloud/integrating-orama-cloud/official-sdk). 
+Once your data is imported and your index is up and running, you can start performing search queries using one of our Official SDKs. Orama offers SDKs for [JavaScript](/cloud/integrating-orama-cloud/official-sdk), [Swift](/cloud/integrating-orama-cloud/official-sdk), [Kotlin](/cloud/integrating-orama-cloud/official-sdk), [PHP](/cloud/integrating-orama-cloud/official-sdk) and [Python](/cloud/integrating-orama-cloud/official-sdk). 
 
 The Official SDKs are the recommended way to communicate with Orama Cloud, providing out of the box connection management, cache, telemetry, and type safety for all your search operations.
 


### PR DESCRIPTION
Fix typo: Add missing "of" in SDK usage description

Changed "using one our Official SDKs" to "using one of our Official SDKs" to improve grammar and clarity.